### PR TITLE
[fix] 去除 zms-agent 打包 jar-with-dependencies 后缀

### DIFF
--- a/zms-agent/pom.xml
+++ b/zms-agent/pom.xml
@@ -66,6 +66,7 @@
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
+                    <appendAssemblyId>false</appendAssemblyId>
                     <archive>
                         <manifest>
                             <mainClass>com.zto.zms.agent.AgentServer</mainClass>


### PR DESCRIPTION
assembly.xml 配置中并未带  jar-with-dependencies 后缀